### PR TITLE
Improved inventory system

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,4 +4,4 @@ logs/
 *.swp
 roguepupu2
 *.txt
-gitrepo.sh
+*.sh

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 # Compiler and flags
 CXX := g++
-CXXFLAGS := -Wall -Wextra -Werror -Iheaders -MMD -MP -O3# -std=c++20
+CXXFLAGS := -Wall -Wextra -Werror -Iheaders -flarge-source-files -MMD -MP -O3 -std=c++20
 
 LDFLAGS := -lncursesw -lpanelw -lm
 

--- a/data/items/armor.json
+++ b/data/items/armor.json
@@ -6,7 +6,7 @@
 		"armor": {
 			"proficiency": "light",
 			"armor_class": 11,
-			"stealth_disadvantage": true
+			"stealth": "disadvantage"
 		},
 		"value": 5
 	},
@@ -66,7 +66,7 @@
 			"proficiency": "medium",
 			"armor_class": 14,
 			"max_dexbonus": 2,
-			"stealth_disadvantage": true
+			"stealth": "disadvantage"
 		}
 	},
 
@@ -91,7 +91,7 @@
 			"proficiency": "medium",
 			"armor_class": 15,
 			"max_dexbonus": 2,
-			"stealth_disadvantage": true
+			"stealth": "disadvantage"
 		}
 	},
 
@@ -104,7 +104,7 @@
 			"proficiency": "heavy",
 			"armor_class": 14,
 			"max_dexbonus": 0,
-			"stealth_disadvantage": true
+			"stealth": "disadvantage"
 		}
 	},
 
@@ -117,7 +117,7 @@
 			"proficiency": "heavy",
 			"armor_class": 16,
 			"max_dexbonus": 0,
-			"stealth_disadvantage": true,
+			"stealth": "disadvantage",
 			"strength_requirement": 13
 		}
 	},
@@ -131,7 +131,7 @@
 			"proficiency": "heavy",
 			"armor_class": 17,
 			"max_dexbonus": 0,
-			"stealth_disadvantage": true,
+			"stealth": "disadvantage",
 			"strength_requirement": 15
 		}
 	},
@@ -145,7 +145,7 @@
 			"proficiency": "heavy",
 			"armor_class": 18,
 			"max_dexbonus": 0,
-			"stealth_disadvantage": true,
+			"stealth": "disadvantage",
 			"strength_requirement": 15
 		}
 	}

--- a/data/items/weapons.json
+++ b/data/items/weapons.json
@@ -114,7 +114,7 @@
 		},
 		"weapon": {
 			"proficiency": "simple",
-			"properties": ["versatile"]
+			"properties": ["versatile (1d8)"]
 		},
 		"value": 2
 	},
@@ -144,7 +144,7 @@
 		},
 		"weapon": {
 			"proficiency": "simple",
-			"properties": ["thrown 20/60", "versatile"]
+			"properties": ["thrown 20/60", "versatile (1d8)"]
 		},
 		"value": 1
 	},

--- a/headers/Components.hpp
+++ b/headers/Components.hpp
@@ -97,6 +97,6 @@ struct Armor
 	std::string proficiency;
 	size_t armor_class;
 	size_t max_dexbonus;
-	bool stealth_disadvantage;
+	std::string stealth;
 	size_t strength_requirement;
 };

--- a/headers/ECS.hpp
+++ b/headers/ECS.hpp
@@ -1,13 +1,26 @@
 #pragma once
 
 #include <string>
+#include <map>
 #include "entt.hpp"
 #include "Color.hpp"
+#include "Components.hpp"
+
+#define MELEE_RANGE 1.5
 
 namespace ECS
 {
+	std::string get_category(const entt::registry& registry, const entt::entity entity);
 	Color get_rarity_color(const std::string& rarity);
 	Color get_color(const entt::registry& registry, const entt::entity entity);
+	wchar_t get_glyph(const entt::registry& registry, const entt::entity entity);
+	std::string get_name(const entt::registry& registry, const entt::entity entity);
 	std::string get_colored_name(const entt::registry& registry, const entt::entity entity);
-	std::string get_description(const entt::registry& registry, const entt::entity entity);
+	std::string get_proficiency_requirement(const entt::registry& registry, const entt::entity entity);
+	size_t get_armor_class(const entt::registry& registry, const entt::entity entity);
+	Damage get_damage(const entt::registry& registry, const entt::entity entity);
+	Dice get_versatile_dice(const entt::registry& registry, const entt::entity entity);
+	bool has_weapon_property(const entt::registry& registry, const entt::entity entity, const std::string& property);
+	std::map<std::string, std::string> get_info(const entt::registry& registry, const entt::entity entity);
+	Cell* get_cell(const entt::registry& registry, const entt::entity entity);
 };

--- a/headers/Game.hpp
+++ b/headers/Game.hpp
@@ -28,7 +28,7 @@ class Game
 
 	public:
 		Game();
-		void start();
+		void loop();
 		void end();
 		void check_change_level();
 };

--- a/headers/MenuTxt.hpp
+++ b/headers/MenuTxt.hpp
@@ -6,7 +6,7 @@ class MenuTxt : public MenuElt
 {
 	public:
 		MenuTxt(const std::string& text) : MenuElt(text, MenuElt::Type::TEXT) {}
-		size_t get_size() const override { return text.size(); }
+		size_t get_size() const override;
 		std::any get_value() const override { return {}; }
 		std::function<void()> get_func() const override { return nullptr; }
 };

--- a/headers/Utils.hpp
+++ b/headers/Utils.hpp
@@ -37,7 +37,6 @@ namespace Screen
 	inline size_t width()	{ return static_cast<size_t>(COLS); }
 
 	inline Coord middle()		{ return {height() / 2, width() / 2 }; }
-	inline Coord top_left()		{ return {0, 0}; }
 	inline Coord top()			{ return {0, width() / 2}; }
 	inline Coord botleft()		{ return {height(), 0}; }
 	inline Coord topright()		{ return {0, width()}; }

--- a/headers/systems/ExamineSystem.hpp
+++ b/headers/systems/ExamineSystem.hpp
@@ -1,0 +1,13 @@
+#pragma once
+
+#include <vector>
+#include <string>
+#include "entt.hpp"
+#include "Cave.hpp"
+
+namespace ExamineSystem
+{
+	std::vector<entt::entity> get_clicked_entities(Cave& cave, const size_t player_idx);
+	std::vector<std::string> get_info_neat(const entt::registry& registry, const entt::entity entity);
+	void show_entities_info(entt::registry& registry, std::vector<entt::entity>& entities);
+};

--- a/headers/systems/InventorySystem.hpp
+++ b/headers/systems/InventorySystem.hpp
@@ -10,5 +10,6 @@ namespace InventorySystem
 	void remove_item(entt::registry& registry, const entt::entity entity, const entt::entity item);
 	void add_item(entt::registry& registry, const entt::entity entity, const entt::entity item);
 	void loot_item(entt::registry& registry, const entt::entity looter, const entt::entity owner, const entt::entity item);
+	void pick_up(entt::registry& registry, const entt::entity picker, const entt::entity entity);
 	void open_inventory(entt::registry& registry, const entt::entity entity);
 };

--- a/sources/Cell.cpp
+++ b/sources/Cell.cpp
@@ -6,6 +6,7 @@
 #include "UI.hpp"          // for UI
 #include "World.hpp"       // for World
 #include "entt.hpp"        // for vector, basic_sigh_mixin, entity, map, size_t
+#include "ECS.hpp"
 
 Cell::Cell() : idx(SIZE_MAX), type(Type::NONE), density(0) {}
 
@@ -71,7 +72,7 @@ ColorPair Cell::get_color_pair() const
 	{
 		size_t ln = UI::instance().get_loop_number();
 		const auto& e = entities[ln % entities.size()];
-		ret_fg = cave->get_world()->get_registry().get<Renderable>(e).color;
+		ret_fg = ECS::get_color(cave->get_world()->get_registry(), e);
 	}
 	else
 		ret_fg = this->fg;
@@ -121,5 +122,5 @@ wchar_t Cell::get_glyph() const
 		return glyph;
 
 	const auto& entity = entities[UI::instance().get_loop_number() % entities_size];
-	return cave->get_world()->get_registry().get<Renderable>(entity).glyph;
+	return ECS::get_glyph(cave->get_world()->get_registry(), entity);
 }

--- a/sources/Dice.cpp
+++ b/sources/Dice.cpp
@@ -5,7 +5,7 @@
 #include <string>     // for basic_string, stoi, string
 #include "Dice.hpp"   // for Dice
 
-Dice::Dice(const std::string& str) : n(0), sides(0), mod(0), string(str)
+Dice::Dice(const std::string& str) : n(0), sides(0), mod(0), string("")
 {
 	if (str.find('d') == std::string::npos)
 		mod = std::stoi(str);
@@ -20,9 +20,11 @@ Dice::Dice(const std::string& str) : n(0), sides(0), mod(0), string(str)
 		if (mod_pos != std::string::npos)
 			mod = std::stoi(str.substr(mod_pos));
 	}
+	if (n > 0)
+		string += std::to_string(n) + "d" + std::to_string(sides);
+	if (mod != 0)
+		string += (mod > 0 && n > 0 ? "+" : "") + std::to_string(mod);
 }
-
-Dice::Dice(const int n, const int sides, const int mod) : n(n), sides(sides), mod(mod) {}
 
 int Dice::roll(int advantage) const
 {

--- a/sources/ECS.cpp
+++ b/sources/ECS.cpp
@@ -1,4 +1,6 @@
 #include <string>
+#include <vector>
+#include <map>
 #include "entt.hpp"
 #include "ECS.hpp"
 #include "Color.hpp"
@@ -7,6 +9,11 @@
 
 namespace ECS
 {
+	std::string get_category(const entt::registry& registry, const entt::entity entity)
+	{
+		return registry.get<Category>(entity).category;
+	}
+
 	Color get_rarity_color(const std::string& rarity)
 	{
 		if (rarity == "common")
@@ -35,13 +42,158 @@ namespace ECS
 		return c;
 	}
 
+	wchar_t get_glyph(const entt::registry& registry, const entt::entity entity)
+	{
+		if (registry.all_of<Renderable>(entity))
+		{
+			wchar_t glyph = registry.get<Renderable>(entity).glyph;
+			if (glyph != L'?')
+				return glyph;
+		}
+		return get_name(registry, entity).front();
+	}
+
+	std::string get_name(const entt::registry& registry, const entt::entity entity)
+	{
+		if (!registry.all_of<Name>(entity))
+			return "undefined";
+		return registry.get<Name>(entity).name;
+	}
+
 	std::string get_colored_name(const entt::registry& registry, const entt::entity entity)
 	{
 		const auto& color = get_color(registry, entity);
-		const auto& name = registry.get<Name>(entity).name;
-
+		const auto& name = get_name(registry, entity);
 		std::string colored_name = color.markup() + Utils::capitalize(name) + "{reset}";
-
 		return colored_name;
+	}
+
+	size_t get_armor_class(const entt::registry& registry, const entt::entity entity)
+	{
+		if (registry.all_of<Armor>(entity))
+			return registry.get<Armor>(entity).armor_class;
+		return 0;
+	}
+
+	Damage get_damage(const entt::registry& registry, const entt::entity entity)
+	{
+		if (!registry.all_of<Damage>(entity))
+			return Damage{};
+		return registry.get<Damage>(entity);
+	}
+
+	std::string get_proficiency_requirement(const entt::registry& registry, const entt::entity entity)
+	{
+		const auto& subcategory = registry.get<Subcategory>(entity).subcategory;
+		if (subcategory == "weapons")
+			return registry.get<Weapon>(entity).proficiency;
+		if (subcategory == "armor")
+			return registry.get<Armor>(entity).proficiency;
+		return "";
+	}
+
+	Dice get_versatile_dice(const entt::registry& registry, const entt::entity entity)
+	{
+		if (registry.all_of<Weapon>(entity))
+			return registry.get<Weapon>(entity).versatile_dice;
+		return Dice{};
+	}
+
+	std::vector<std::string> get_properties(const entt::registry& registry, const entt::entity entity)
+	{
+		if (registry.all_of<Weapon>(entity))
+			return registry.get<Weapon>(entity).properties;
+		return {};
+	}
+
+	double get_normal_range(const entt::registry& registry, const entt::entity entity)
+	{
+		if (registry.all_of<Weapon>(entity))
+			return registry.get<Weapon>(entity).normal_range;
+		return 0;
+	}
+
+	double get_long_range(const entt::registry& registry, const entt::entity entity)
+	{
+		if (registry.all_of<Weapon>(entity))
+			return registry.get<Weapon>(entity).long_range;
+		return 0;
+	}
+
+	double get_weight(const entt::registry& registry, const entt::entity entity)
+	{
+		if (registry.all_of<Weight>(entity))
+			return registry.get<Weight>(entity).lb;
+		return 0;
+	}
+
+	size_t get_value(const entt::registry& registry, const entt::entity entity)
+	{
+		if (registry.all_of<Value>(entity))
+			return registry.get<Value>(entity).value;
+		return 0;
+	}
+
+	bool has_weapon_property(const entt::registry& registry, const entt::entity entity, const std::string& property)
+	{
+		if (!registry.all_of<Weapon>(entity))
+			return false;
+		const auto& properties = registry.get<Weapon>(entity).properties;
+		return std::find(properties.begin(), properties.end(), property) != properties.end();
+	}
+
+	Cell* get_cell(const entt::registry& registry, const entt::entity entity)
+	{
+		if (registry.all_of<Position>(entity))
+			return registry.get<Position>(entity).cell;
+		return nullptr;
+	}
+
+	std::map<std::string, std::string> get_info(const entt::registry& registry, const entt::entity entity)
+	{
+		std::map<std::string, std::string> info;
+
+		std::string proficiency = get_proficiency_requirement(registry, entity);
+		if (!proficiency.empty())
+			info["Proficiency"] = proficiency;
+
+		Damage damage = get_damage(registry, entity);
+		if (!damage.type.empty())
+		{
+			std::string dmg_str = damage.dice.get_string();
+			Dice versatile_dice = get_versatile_dice(registry, entity);
+			if (!versatile_dice.get_string().empty())
+				dmg_str += "/" + versatile_dice.get_string();
+			dmg_str += " " + damage.type;
+			info["Damage"] = dmg_str;
+		}
+
+		size_t armor_class = get_armor_class(registry, entity);
+		if (armor_class > 0)
+			info["AC"] = std::to_string(armor_class);
+
+		std::vector<std::string> properties = get_properties(registry, entity);
+		std::string propstring("");
+		for (size_t i = 0; i < properties.size(); ++i)
+			propstring += properties[i] + (i < properties.size() - 1 ? " | " : "");
+		if (!propstring.empty())
+			info["Properties"] = propstring;
+
+		double normal_range = get_normal_range(registry, entity);
+		double long_range = get_long_range(registry, entity);
+		if (normal_range > MELEE_RANGE || long_range > MELEE_RANGE)
+			info["Range"] = std::format("{:.1f}", normal_range) + "/" + std::format("{:.1f}", long_range) + " cells";
+		else if (normal_range == MELEE_RANGE)
+			info["Range"] = "Melee";
+
+		double weight = get_weight(registry, entity);
+		if (weight > 0.0)
+			info["Weight"] = std::format("{:.1f}", weight) + " lb";
+
+		size_t value = get_value(registry, entity);
+		if (value > 0)
+			info["Value"] = std::to_string(value) + " gp";
+
+		return info;
 	}
 };

--- a/sources/EntityFactory.cpp
+++ b/sources/EntityFactory.cpp
@@ -194,9 +194,9 @@ std::unordered_map<std::string, FieldParser> field_parsers =
 			const std::string proficiency = data["proficiency"].get<std::string>();
 			const size_t armor_class = data.contains("armor_class") ? data["armor_class"].get<size_t>() : 0;
 			const size_t max_dexbonus = data.contains("max_dexbonus") ? data["max_dexbonus"].get<size_t>() : SIZE_MAX;
-			const bool stealth_disadvantage = data.contains("stealth_disadvantage") ? data["stealth_disadvantage"].get<bool>() : false;
+			const std::string stealth = data.contains("stealth") ? data["stealth"].get<std::string>() : "";
 			const size_t strength_requirement = data.contains("strength_requirement") ? data["strength_requirement"].get<size_t>() : 0;
-			reg.template emplace<Armor>(e, proficiency, armor_class, max_dexbonus, stealth_disadvantage, strength_requirement);
+			reg.template emplace<Armor>(e, proficiency, armor_class, max_dexbonus, stealth, strength_requirement);
 		}
 	}
 };

--- a/sources/EntityFactory.cpp
+++ b/sources/EntityFactory.cpp
@@ -15,7 +15,7 @@
 class Cell;
 
 #define CELL_SIZE 5
-
+#define MELEE_RANGE 1.5
 void EntityFactory::init()
 {
 	read_definitions("data/items/weapons.json");
@@ -134,7 +134,7 @@ std::unordered_map<std::string, FieldParser> field_parsers =
 			std::vector<std::string> properties = data["properties"].get<std::vector<std::string>>();
 
 			// Parse more data from properties
-			double normal_range = 1.5, long_range = 1.5;
+			double normal_range = MELEE_RANGE, long_range = MELEE_RANGE;
 			Dice versatile_dice;
 			for (auto& property : properties)
 			{

--- a/sources/Game.cpp
+++ b/sources/Game.cpp
@@ -12,6 +12,8 @@
 #include "entt.hpp"                     // for allocator, vector, size_t
 #include "systems/InventorySystem.hpp"  // for inventory_key_pressed, open_i...
 #include "systems/MovementSystem.hpp"   // for move, movement_key_pressed
+#include "systems/ExamineSystem.hpp"
+#include "ECS.hpp"
 
 Game::Game() :
 	level(1),
@@ -41,7 +43,7 @@ void Game::check_change_level()
 	level += d;
 }
 
-void Game::start()
+void Game::loop()
 {
 	get_cave().draw();
 
@@ -67,6 +69,11 @@ void Game::start()
 			key = 0;
 			continue;
 		}
+		if (key == KEY_LEFT_CLICK)
+		{
+			auto entities = ExamineSystem::get_clicked_entities(get_cave(), ECS::get_cell(get_registry(), player)->get_idx());
+			ExamineSystem::show_entities_info(get_registry(), entities);
+		}
 
 		get_cave().draw();
 		UI::instance().increase_loop_number();
@@ -86,12 +93,14 @@ void Game::end()
 // Called by main menu
 void new_game()
 {
+	PANEL* game_panel = new_panel(newwin(Screen::height(), Screen::width(), 0, 0));
+	UI::instance().add_panel(UI::Panel::GAME, game_panel);
 	UI::instance().set_mode(UI::Mode::GAME);
 	PANEL* panel = UI::instance().get_panel(UI::Panel::GAME);
 	UI::instance().set_current_panel(panel, true);
 
 	Game game;
-	game.start();
+	game.loop();
 	game.end();
 	UI::instance().set_mode(UI::Mode::MAIN);
 }

--- a/sources/MenuTxt.cpp
+++ b/sources/MenuTxt.cpp
@@ -1,0 +1,14 @@
+#include "MenuTxt.hpp"
+
+size_t MenuTxt::get_size() const
+{
+	size_t markup_len = 0;
+	size_t pos = 0;
+	// Return the length of text, but subtract length of possible color markup
+	while (text.find('{', pos) != std::string::npos && text.find('}', pos) != std::string::npos) // contains markups
+	{
+		markup_len += text.find('}', pos) - text.find('{', pos);
+		pos = text.find('}', pos) + 1;
+	}
+	return text.size() - markup_len;
+}

--- a/sources/Tester.cpp
+++ b/sources/Tester.cpp
@@ -1,8 +1,10 @@
+#include <iostream>
 #include <stdexcept>
 #include <nlohmann/json.hpp>
 #include <vector>
 #include <string>
 #include <map>
+#include "ECS.hpp"
 #include "EntityFactory.hpp"
 #include "Utils.hpp"
 #include "entt.hpp"
@@ -31,6 +33,11 @@ size_t test_equipping_all_weapons()
 		for (const auto& weapon_name : all_weapon_names)
 		{
 			const auto test_weapon = EntityFactory::instance().create_entity(test_registry, weapon_name);
+			if (ECS::has_weapon_property(test_registry, test_weapon, "versatile") && ECS::get_versatile_dice(test_registry, test_weapon).get_string().empty())
+			{
+				Log::tester_log(Log::Type::TEST_FAIL, "Expected a versatile weapon to have versatile dice");
+				failed++;
+			}
 			EquipmentSystem::equip(test_registry, test_entity, test_weapon);
 			if (!EquipmentSystem::is_equipped(test_registry, test_entity, test_weapon))
 			{
@@ -49,5 +56,6 @@ size_t tester()
 	Log::tester_log(Log::Type::INFO, "-- Starting tester --");
 	failed += test_equipping_all_weapons();
 	Log::tester_log(Log::Type::INFO, "Tester finished with " + std::to_string(failed) + " failed tests");
+	std::cout << "Tester finished with " << failed << " failed tests" << std::endl;
 	return failed;
 }

--- a/sources/UI.cpp
+++ b/sources/UI.cpp
@@ -280,12 +280,6 @@ void UI::init_menus()
 	menus["cell_info"].set_read_only(true);
 }
 
-void UI::init_panels()
-{
-	PANEL* game = new_panel(newwin(Screen::height(), Screen::width(), 0, 0));
-	UI::instance().add_panel(UI::Panel::GAME, game);
-}
-
 void UI::init()
 {
 	loop_number = 0;
@@ -293,7 +287,6 @@ void UI::init()
 	initscr();
 	start_color();
 	init_menus();
-	init_panels();
 
 	// signals should reset original terminal mode
 	std::signal(SIGSEGV, handle_signal);

--- a/sources/systems/ExamineSystem.cpp
+++ b/sources/systems/ExamineSystem.cpp
@@ -1,0 +1,113 @@
+#include <format>
+#include "systems/ExamineSystem.hpp"
+#include "UI.hpp"
+#include "Utils.hpp"
+#include "ECS.hpp"
+
+namespace ExamineSystem
+{
+	std::vector<entt::entity> get_clicked_entities(Cave& cave, const size_t player_idx)
+	{
+		Screen::Coord mouse_position = UI::instance().get_mouse_position();
+		PANEL* panel = UI::instance().get_panel(UI::Panel::GAME);
+		WINDOW* window = panel_window(panel);
+		int window_height, window_width, window_starty, window_startx;
+		getmaxyx(window, window_height, window_width);
+		getbegyx(window, window_starty, window_startx);
+
+		int mouse_y = mouse_position.y - window_starty;
+		int mouse_x = mouse_position.x - window_startx;
+
+		int window_center_y = window_height / 2;
+		int window_center_x = window_width / 2;
+
+		int offset_y = mouse_y - window_center_y;
+		int offset_x = mouse_x - window_center_x;
+
+		int player_y = player_idx / cave.get_width();
+		int player_x = player_idx % cave.get_width();
+
+		int dest_y = player_y + offset_y;
+		int dest_x = player_x + offset_x;
+		const size_t dest_idx = dest_y * cave.get_width() + dest_x;
+
+		auto entities = cave.get_cell(dest_idx).get_entities();
+		return entities;
+	}
+
+	std::vector<std::string> get_info_neat(const entt::registry& registry, const entt::entity entity)
+	{
+		const auto& info = ECS::get_info(registry, entity);
+		size_t leftcol = 0;
+		size_t rightcol = 0;
+		for (const auto& [left, right] : info)
+		{
+			leftcol = std::max(leftcol, left.size());
+			rightcol = std::max(rightcol, right.size());
+		}
+
+		std::vector<std::string> info_neat = { ECS::get_colored_name(registry, entity) };
+		for (const auto& [left, right] : info)
+			info_neat.push_back(std::format("{: <{}} : {: >{}}", left, leftcol, right, rightcol));
+		return info_neat;
+	}
+
+	void add_item(entt::registry& registry, const entt::entity entity, const entt::entity item)
+	{
+		auto& inventory = registry.get<Inventory>(entity).inventory;
+		inventory.push_back(item);
+	}
+
+	void pick_up(entt::registry& registry, const entt::entity picker, const entt::entity entity)
+	{
+		registry.remove<Position>(entity);
+		add_item(registry, picker, entity);
+
+		if (registry.all_of<Glow>(entity))
+			ECS::get_cell(registry, picker)->get_cave()->reset_lights();
+	}
+
+	void show_entities_info(entt::registry& registry, std::vector<entt::entity>& entities)
+	{
+		if (entities.empty())
+			return;
+		std::vector<std::string> options;
+		options.push_back("Next");
+		const auto player = *registry.view<Player>().begin();
+		Cell* player_cell = ECS::get_cell(registry, player);
+		Cell* entity_cell = ECS::get_cell(registry, entities[0]); // all entities are in the same cell so any will work
+		if (player_cell->get_cave()->distance(*player_cell, *entity_cell) <= MELEE_RANGE)
+			options.push_back("Pick up");
+		options.push_back("Cancel");
+
+		auto it = entities.begin();
+		while (!entities.empty())
+		{
+			auto valid_options = options;
+			if (entities.size() == 1)
+				valid_options.erase(std::find(valid_options.begin(), valid_options.end(), "Next"));
+
+			const auto& category = ECS::get_category(registry, *it);
+			if (category != "items" && ECS::get_name(registry, *it) != "glowing mushroom") // testing picking mushrooms
+				valid_options.erase(std::find(valid_options.begin(), valid_options.end(), "Pick up"));
+
+			assert(std::find(valid_options.begin(), valid_options.end(), "Cancel") != valid_options.end());
+
+			const auto& info_neat = get_info_neat(registry, *it);
+			const auto& selected = UI::instance().dialog(info_neat, valid_options, Screen::topleft());
+			if (selected == "Next")
+			{
+				if (++it == entities.end())
+					it = entities.begin();
+			}
+			else if (selected == "Pick up")
+			{
+				pick_up(registry, player, *it);
+				it = entities.erase(it);
+				player_cell->get_cave()->draw();
+			}
+			else if (selected == "Cancel" || selected.empty())
+				break;
+		}
+	}
+};

--- a/sources/systems/ExamineSystem.cpp
+++ b/sources/systems/ExamineSystem.cpp
@@ -85,11 +85,19 @@ namespace ExamineSystem
 		{
 			auto valid_options = options;
 			if (entities.size() == 1)
-				valid_options.erase(std::find(valid_options.begin(), valid_options.end(), "Next"));
+			{
+				auto it_next = std::find(valid_options.begin(), valid_options.end(), "Next");
+				if (it_next != valid_options.end())
+					valid_options.erase(it_next);
+			}
 
 			const auto& category = ECS::get_category(registry, *it);
-			if (category != "items" && ECS::get_name(registry, *it) != "glowing mushroom") // testing picking mushrooms
-				valid_options.erase(std::find(valid_options.begin(), valid_options.end(), "Pick up"));
+			if (category != "items" && ECS::get_name(registry, *it) != "glowing mushroom")
+			{
+				auto it_pick = std::find(valid_options.begin(), valid_options.end(), "Pick up");
+				if (it_pick != valid_options.end())
+					valid_options.erase(it_pick);
+			}
 
 			assert(std::find(valid_options.begin(), valid_options.end(), "Cancel") != valid_options.end());
 

--- a/sources/systems/InventorySystem.cpp
+++ b/sources/systems/InventorySystem.cpp
@@ -1,10 +1,13 @@
-#include <string>                       // for basic_string, operator+, char...
-#include "Components.hpp"               // for Inventory, Name, Player (ptr ...
-#include "ECS.hpp"                      // for get_name, get_description
+#include <string>                       // for basic_string, char_traits
+#include "Cave.hpp"                     // for Cave
+#include "Cell.hpp"                     // for Cell
+#include "Components.hpp"               // for Position, Inventory, Name
+#include "ECS.hpp"                      // for get_cell, get_colored_name
 #include "UI.hpp"                       // for UI
-#include "Utils.hpp"                    // for error, capitalize, top_left
+#include "Utils.hpp"                    // for topleft, capitalize
 #include "entt.hpp"                     // for vector, allocator, basic_sigh...
-#include "systems/EquipmentSystem.hpp"  // for equip_or_unequip, is_equipped
+#include "systems/EquipmentSystem.hpp"  // for is_equipped, equip_or_unequip
+#include "systems/ExamineSystem.hpp"    // for get_info_neat
 #include "systems/InventorySystem.hpp"  // for add_item, has_item, inventory...
 
 namespace InventorySystem
@@ -14,7 +17,7 @@ namespace InventorySystem
 		return key == 'i';
 	}
 
-	std::vector<std::string> get_item_names(const entt::registry& registry, const std::vector<entt::entity>& items)
+	std::vector<std::string> get_colored_item_names(const entt::registry& registry, const std::vector<entt::entity>& items)
 	{
 		auto player = *registry.view<Player>().begin();
 		std::vector<std::string> names;
@@ -36,6 +39,8 @@ namespace InventorySystem
 
 	void remove_item(entt::registry& registry, const entt::entity entity, const entt::entity item)
 	{
+		if (EquipmentSystem::is_equipped(registry, entity, item))
+			EquipmentSystem::unequip(registry, entity, item);
 		auto& inventory = registry.get<Inventory>(entity).inventory;
 		auto it = std::find(inventory.begin(), inventory.end(), item);
 		inventory.erase(it);
@@ -53,56 +58,16 @@ namespace InventorySystem
 		add_item(registry, looter, item);
 	}
 
-	std::string get_proficiency(const entt::registry& registry, const entt::entity item)
+	void drop_item(entt::registry& registry, const entt::entity owner, const entt::entity item)
 	{
-		std::string proficiency = "";
-		if (registry.all_of<Weapon>(item))
-			proficiency = registry.get<Weapon>(item).proficiency + " weapons";
-		if (registry.all_of<Armor>(item))
-			proficiency = registry.get<Armor>(item).proficiency + " armor";
-		return Utils::capitalize(proficiency);
-	}
-
-	std::string get_damage(const entt::registry& registry, const entt::entity item)
-	{
-		std::string damage = "", versatile_damage = "";
-		if (registry.all_of<Damage>(item))
+		remove_item(registry, owner, item);
+		Cell* cell = ECS::get_cell(registry, owner);
+		registry.emplace<Position>(item, cell);
+		if (registry.all_of<Glow>(item))
 		{
-			const auto& dmg_cmp = registry.get<Damage>(item);
-			damage += dmg_cmp.dice.get_string() + " ";
-			if (registry.all_of<Weapon>(item))
-				versatile_damage = registry.get<Weapon>(item).versatile_dice.get_string();
-			if (!versatile_damage.empty())
-				damage += "( " + versatile_damage + " ) ";
-			damage += dmg_cmp.type;
+			cell->get_cave()->reset_lights();
+			cell->get_cave()->draw();
 		}
-		return Utils::capitalize(damage);
-	}
-
-	std::string get_armor_class(const entt::registry& registry, const entt::entity item)
-	{
-		if (registry.all_of<Armor>(item))
-			return std::to_string(registry.get<Armor>(item).armor_class);
-		return "";
-	}
-
-	std::vector<std::string> get_item_stats(const entt::registry& registry, const entt::entity item)
-	{
-		std::vector<std::string> stats = {"*** " + ECS::get_colored_name(registry, item) + " ***"};
-
-		std::string proficiency = get_proficiency(registry, item);
-		if (!proficiency.empty())
-			stats.push_back("Proficiency: " + proficiency);
-
-		std::string damage = get_damage(registry, item);
-		if (!damage.empty())
-			stats.push_back("Damage: " + damage);
-
-		std::string armor_class = get_armor_class(registry, item);
-		if (!armor_class.empty())
-			stats.push_back("AC: " + armor_class);
-
-		return stats;
 	}
 
 	std::vector<std::string> get_options(const entt::registry& registry, const entt::entity owner, const entt::entity item)
@@ -120,6 +85,7 @@ namespace InventorySystem
 			}
 		}
 		else options.push_back("Loot");
+		options.push_back("Drop");
 		options.push_back("Cancel");
 		return options;
 	}
@@ -137,10 +103,10 @@ namespace InventorySystem
 		{
 			// Create list of items to show in inventory window
 			auto& items = registry.get<Inventory>(owner).inventory;
-			const auto& names = get_item_names(registry, items);
+			const auto& names = get_colored_item_names(registry, items);
 
 			// Dialog returns selection
-			selection = UI::instance().dialog("*** " + Utils::capitalize(owner_name) + " ***", names, Screen::top_left(), idx + 1);
+			selection = UI::instance().dialog("*** " + Utils::capitalize(owner_name) + " ***", names, Screen::topleft(), idx + 1);
 			if (selection.empty()) // Esc was pressed
 				break;
 
@@ -149,14 +115,15 @@ namespace InventorySystem
 			idx = it - names.begin();
 			auto& item = items[idx];
 
-			// Show stats and options
-			const auto& stats = get_item_stats(registry, item);
 			const auto& options = get_options(registry, owner, item);
-			selection = UI::instance().dialog(stats, options, Screen::top_left());
+			const auto& info_neat = ExamineSystem::get_info_neat(registry, item);
+			selection = UI::instance().dialog(info_neat, options, Screen::topleft());
 			if (selection == "Equip" || selection == "Unequip")
 				EquipmentSystem::equip_or_unequip(registry, player, item);
 			else if (selection == "Loot")
 				loot_item(registry, player, owner, item);
+			else if (selection == "Drop")
+				drop_item(registry, owner, item);
 		}
 	}
 };


### PR DESCRIPTION
- Armor component "stealth_disadvantage": bool change to "stealth": "advantage" or "disadvantage" or ""
- Query information about entities with namespace ECS
- Check equipment slot with registry.get<Subcategory>(entity).subcategory ("weapons", "armor", "helmets"...)
- Showing all relevant info when examining an item in inventory
- Fixed crash when starting a new game after exiting one previously. Now creates a new ncurses panel and doesnt use a destroyed one
- Compile with c++20 for format
- A couple of weapons were missing versatile dice. Added a test for it
- Clicking on an entity will show its info (loops if multiple in same cell)
- Implemented an ExamineSystem which is used to examine entities
- Can drop entities from inventory
- Can pick up entities from ground if they are within melee range (1.5 cells) from examine menu
- If picked up or dropped entity has Glow component, update lights in cave